### PR TITLE
Start send loop and stream Gemini audio

### DIFF
--- a/cog.py
+++ b/cog.py
@@ -83,6 +83,7 @@ class PartyBot(commands.Cog):
                 model_id=guild_config["model_id"],
             )
             await gemini_session.create()
+            gemini_session.start_send_loop()
 
             mixer = Mixer(headroom_db=guild_config["mix_headroom_db"])
             vad = VAD()


### PR DESCRIPTION
## Summary
- queue Gemini audio playback using an async generator
- start LiveSession send loop when a voice session begins

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68653cff646c8329be5b308c76ad6251