### PR TITLE
Improve audio mixing and VAD

### DIFF
--- a/audio/mixer.py
+++ b/audio/mixer.py
@@ -1,51 +1,81 @@
-
 import numpy as np
+from collections import deque
+from typing import Dict
 
 
 class Mixer:
-    """A real-time audio mixer."""
+    """A real-time audio mixer that keeps per-user ring buffers."""
 
-    def __init__(self, sample_rate: int = 48000, channels: int = 1, headroom_db: float = 6):
+    def __init__(
+        self,
+        sample_rate: int = 48000,
+        input_channels: int = 2,
+        headroom_db: float = 6,
+        buffer_ms: int = 1000,
+    ):
         self._sample_rate = sample_rate
-        self._channels = channels
+        self._input_channels = input_channels
         self._headroom = 10 ** (-headroom_db / 20)
-        self._buffer = np.zeros((0, self._channels), dtype=np.float32)
+        self._frame_capacity = int(self._sample_rate * (buffer_ms / 1000.0))
+        self._buffers: Dict[int, deque[np.ndarray]] = {}
 
-    def add(self, pcm_data: np.ndarray):
-        """Adds PCM data to the mixer."""
-        if pcm_data.shape[1] != self._channels:
+    def _to_mono(self, pcm_data: np.ndarray) -> np.ndarray:
+        """Converts incoming audio to mono float32."""
+        pcm = np.asarray(pcm_data, dtype=np.float32)
+        if pcm.ndim == 1:
+            if self._input_channels > 1:
+                if len(pcm) % self._input_channels != 0:
+                    raise ValueError("PCM length must be divisible by number of channels")
+                pcm = pcm.reshape(-1, self._input_channels)
+            else:
+                pcm = pcm.reshape(-1, 1)
+        elif pcm.shape[1] != self._input_channels:
             raise ValueError("PCM data must have the same number of channels as the mixer")
+        return pcm.mean(axis=1)
 
-        if len(self._buffer) < len(pcm_data):
-            self._buffer = np.pad(
-                self._buffer,
-                ((0, len(pcm_data) - len(self._buffer)), (0, 0)),
-                mode="constant",
-            )
-        elif len(self._buffer) > len(pcm_data):
-            pcm_data = np.pad(
-                pcm_data,
-                ((0, len(self._buffer) - len(pcm_data)), (0, 0)),
-                mode="constant",
-            )
+    def add(self, user_id: int, pcm_data: np.ndarray):
+        """Adds PCM data from a user to the mixer."""
+        mono = self._to_mono(pcm_data)
+        if user_id not in self._buffers:
+            self._buffers[user_id] = deque()
+        self._buffers[user_id].append(mono)
 
-        self._buffer += pcm_data
+        total = sum(len(chunk) for chunk in self._buffers[user_id])
+        while total > self._frame_capacity and self._buffers[user_id]:
+            removed = self._buffers[user_id].popleft()
+            total -= len(removed)
 
     def pop(self, duration_ms: int) -> np.ndarray:
-        """Pops a chunk of mixed audio from the buffer."""
+        """Pops a chunk of mixed mono audio from the buffers."""
         num_frames = int(self._sample_rate * (duration_ms / 1000.0))
-        if len(self._buffer) < num_frames:
-            return np.zeros((0, self._channels), dtype=np.float32)
+        if num_frames <= 0:
+            return np.zeros(0, dtype=np.float32)
 
-        chunk = self._buffer[:num_frames]
-        self._buffer = self._buffer[num_frames:]
+        mixed = np.zeros(num_frames, dtype=np.float32)
+        for dq in self._buffers.values():
+            frames_needed = num_frames
+            parts = []
+            while frames_needed > 0 and dq:
+                chunk = dq[0]
+                if len(chunk) <= frames_needed:
+                    parts.append(chunk)
+                    dq.popleft()
+                    frames_needed -= len(chunk)
+                else:
+                    parts.append(chunk[:frames_needed])
+                    dq[0] = chunk[frames_needed:]
+                    frames_needed = 0
 
-        # Apply headroom and clip
-        chunk *= self._headroom
-        np.clip(chunk, -1.0, 1.0, out=chunk)
+            if parts:
+                user_mix = np.concatenate(parts)
+                if len(user_mix) < num_frames:
+                    user_mix = np.pad(user_mix, (0, num_frames - len(user_mix)))
+                mixed += user_mix
 
-        return chunk
+        mixed *= self._headroom
+        np.clip(mixed, -1.0, 1.0, out=mixed)
+        return mixed
 
     def clear(self):
-        """Clears the mixer buffer."""
-        self._buffer = np.zeros((0, self._channels), dtype=np.float32)
+        """Clears all mixer buffers."""
+        self._buffers.clear()

--- a/audio/vad.py
+++ b/audio/vad.py
@@ -1,5 +1,6 @@
 
 import webrtcvad
+import numpy as np
 
 
 class VAD:
@@ -13,8 +14,16 @@ class VAD:
             self._sample_rate * (self._frame_duration_ms / 1000.0) * 2
         )  # 16-bit PCM
 
-    def is_speech(self, frame: bytes, threshold: float = 0.5) -> bool:
-        """Returns True if the frame contains speech."""
+    def is_speech(self, frame: bytes, threshold: float = -float("inf")) -> bool:
+        """Returns True if the frame contains speech above the given threshold."""
         if len(frame) != self._frame_size:
             raise ValueError(f"Frame must be {self._frame_size} bytes")
+
+        if threshold > -float("inf"):
+            pcm = np.frombuffer(frame, dtype=np.int16).astype(np.float32) / 32768.0
+            rms = np.sqrt(np.mean(pcm ** 2))
+            level_db = -np.inf if rms == 0 else 20 * np.log10(rms)
+            if level_db < threshold:
+                return False
+
         return self._vad.is_speech(frame, self._sample_rate)

--- a/cog.py
+++ b/cog.py
@@ -113,7 +113,7 @@ class PartyBot(commands.Cog):
     ):
         """The loop that captures audio from Discord and sends it to Gemini."""
         async for user_id, pcm48 in bridge.recv_frames():
-            mixer.add(pcm48)
+            mixer.add(user_id, pcm48)
 
             chunk = mixer.pop(guild_config["input_buffer_ms"])
             if chunk.size > 0:


### PR DESCRIPTION
## Summary
- redesign `Mixer` to hold per-user ring buffers and mix to mono
- use the `threshold` argument in `VAD.is_speech`
- update capture loop to pass user ID to mixer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68653d01498c83299df7cf0c31b85e97