### PR TITLE
Add mixer, VAD and Gemini session tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,65 @@
+import os
+import sys
+import types
+
+# Avoid shadowing the stdlib logging module
+root = sys.path.pop(0)
+import logging as builtin_logging  # noqa: E402
+sys.modules['logging'] = builtin_logging
+sys.path.insert(0, root)
+
+# Ensure the project package can be imported as 'partybot'
+repo_root = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, os.path.dirname(repo_root))
+
+# Provide minimal stubs for external dependencies used during imports
+# Discord stub with basic classes
+discord_stub = types.ModuleType('discord')
+class VoiceClient: ...
+class AudioSink: ...
+class PCMAudio:
+    def __init__(self, data):
+        self.data = data
+
+discord_stub.VoiceClient = VoiceClient
+discord_stub.AudioSink = AudioSink
+discord_stub.PCMAudio = PCMAudio
+sys.modules.setdefault('discord', discord_stub)
+
+for name in ['redbot', 'redbot.core', 'redbot.core.commands', 'google', 'google.generativeai']:
+    if name not in sys.modules:
+        sys.modules[name] = types.ModuleType(name)
+
+# Commands stub
+actions = sys.modules['redbot.core.commands']
+if not hasattr(actions, 'Cog'):
+    class Cog: ...
+    class Context: ...
+    def command(*d, **k):
+        def deco(f):
+            return f
+        return deco
+    def group(*d, **k):
+        def deco(f):
+            f.command = command
+            return f
+        return deco
+    actions.Cog = Cog
+    actions.Context = Context
+    actions.group = group
+    actions.command = command
+
+# Config stub used in cog imports
+core = sys.modules.get('redbot.core')
+if core and not hasattr(core, 'Config'):
+    class DummyConfig:
+        def get_conf(self, *a, **k):
+            return self
+        def register_guild(self, *a, **k):
+            pass
+        def guild(self, *a, **k):
+            class Dummy:
+                async def all(self):
+                    return {}
+            return Dummy()
+    core.Config = DummyConfig

--- a/tests/test_gemini_session.py
+++ b/tests/test_gemini_session.py
@@ -1,0 +1,57 @@
+import asyncio
+import types
+
+import pytest
+
+import partybot.stream.gemini_session as gs_mod
+
+
+class FakeChunk:
+    def __init__(self, audio):
+        self.audio = audio
+
+
+class FakeLiveSession:
+    def __init__(self, responses):
+        self.sent = []
+        self.responses = responses
+        self.closed = False
+
+    async def send(self, data):
+        self.sent.append(data)
+
+    async def response_iter(self):
+        for resp in self.responses:
+            yield FakeChunk(resp)
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_gemini_session_send_receive(monkeypatch):
+    fake = FakeLiveSession([b'one', b'two'])
+
+    async def fake_live_session(**kwargs):
+        return fake
+
+    monkeypatch.setattr(gs_mod.genai, 'configure', lambda api_key: None, raising=False)
+    monkeypatch.setattr(gs_mod.genai, 'live_session', fake_live_session, raising=False)
+
+    session = gs_mod.GeminiSession(api_key='k', model_id='m')
+    await session.create()
+    send_task = asyncio.create_task(session._send_loop())
+    iter_task = asyncio.create_task(session.iter_audio())
+
+    await session.send_pcm(b'data')
+    await asyncio.sleep(0.01)
+    assert fake.sent == [b'data']
+
+    out1 = await asyncio.wait_for(session.out_q.get(), timeout=1)
+    out2 = await asyncio.wait_for(session.out_q.get(), timeout=1)
+    assert out1 == b'one' and out2 == b'two'
+
+    iter_task.cancel()
+    send_task.cancel()
+    await session.close()
+    assert fake.closed

--- a/tests/test_mixer.py
+++ b/tests/test_mixer.py
@@ -1,0 +1,29 @@
+import numpy as np
+from partybot.audio.mixer import Mixer
+
+
+def test_mixer_add_and_pop():
+    mixer = Mixer(sample_rate=10, channels=1, headroom_db=0)
+    pcm1 = np.full((5, 1), 0.1, dtype=np.float32)
+    pcm2 = np.full((3, 1), 0.2, dtype=np.float32)
+    mixer.add(pcm1)
+    mixer.add(pcm2)
+
+    chunk = mixer.pop(500)  # 5 frames at 10 Hz
+    expected = np.array([0.3, 0.3, 0.3, 0.1, 0.1], dtype=np.float32)
+    assert np.allclose(chunk.flatten(), expected)
+    # buffer should now be empty
+    assert mixer.pop(100).shape[0] == 0
+
+
+def test_mixer_headroom_and_clear():
+    mixer = Mixer(sample_rate=4, channels=1, headroom_db=6)
+    pcm = np.full((4, 1), 1.0, dtype=np.float32)
+    mixer.add(pcm)
+    chunk = mixer.pop(1000)
+    factor = 10 ** (-6 / 20)
+    assert np.allclose(chunk.flatten(), np.ones(4) * factor)
+
+    mixer.add(np.full((1, 1), 0.5, dtype=np.float32))
+    mixer.clear()
+    assert mixer.pop(1000).size == 0

--- a/tests/test_vad.py
+++ b/tests/test_vad.py
@@ -1,0 +1,24 @@
+import pytest
+from partybot.audio.vad import VAD
+
+
+def test_vad_is_speech(monkeypatch):
+    vad = VAD()
+    called = {}
+
+    def fake_is_speech(frame, sample_rate):
+        called['frame'] = frame
+        called['rate'] = sample_rate
+        return True
+
+    monkeypatch.setattr(vad._vad, 'is_speech', fake_is_speech)
+    frame = b'\x00' * vad._frame_size
+    assert vad.is_speech(frame)
+    assert called['frame'] == frame
+    assert called['rate'] == vad._sample_rate
+
+
+def test_vad_frame_size_validation():
+    vad = VAD()
+    with pytest.raises(ValueError):
+        vad.is_speech(b'\x00' * (vad._frame_size - 1))


### PR DESCRIPTION
## Summary
- expand test suite with mixer, VAD and Gemini session tests
- add lightweight stubs for external deps used while importing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68653d02ee60832980dca619cbf387d7