### PR TITLE
Fix Gemini cost constants

### DIFF
--- a/stream/gemini_session.py
+++ b/stream/gemini_session.py
@@ -7,8 +7,8 @@ from partybot.utils.backpressure import BackpressureQueue
 class GeminiSession:
     """A wrapper around the Google Generative AI LiveSession."""
 
-    _INPUT_BYTE_COST = 1.0 / 1_000_000
-    _OUTPUT_BYTE_COST = 1.0 / 1_000_000
+    _INPUT_BYTE_COST = 3e-6
+    _OUTPUT_BYTE_COST = 12e-6
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary
- adjust Gemini session byte cost constants to design spec

## Testing
- `python -m pytest partybot/tests -q` *(fails: module 'discord' has no attribute 'sinks')*

------
https://chatgpt.com/codex/tasks/task_e_686540e25adc8329b1839fe5da04310a