### PR TITLE
Update mixer and Gemini session tests

### DIFF
--- a/tests/test_gemini_session.py
+++ b/tests/test_gemini_session.py
@@ -1,7 +1,26 @@
 import asyncio
 import types
+import sys
 
 import pytest
+
+# Provide a minimal stub for discord.sinks.Sink used in imports
+discord = sys.modules.setdefault('discord', types.ModuleType('discord'))
+if not hasattr(discord, 'sinks'):
+    sinks_mod = types.ModuleType('discord.sinks')
+
+    class Sink:
+        pass
+
+    class Filters:
+        @staticmethod
+        def container(func):
+            return func
+
+    sinks_mod.Sink = Sink
+    sinks_mod.core = types.SimpleNamespace(Filters=Filters(), AudioData=bytes)
+    discord.sinks = sinks_mod
+    sys.modules.setdefault('discord.sinks', sinks_mod)
 
 import partybot.stream.gemini_session as gs_mod
 
@@ -41,15 +60,21 @@ async def test_gemini_session_send_receive(monkeypatch):
     session = gs_mod.GeminiSession(api_key='k', model_id='m')
     await session.create()
     send_task = asyncio.create_task(session._send_loop())
-    iter_task = asyncio.create_task(session.iter_audio())
+
+    outputs = []
+
+    async def run_iter():
+        async for chunk in session.iter_audio():
+            outputs.append(chunk)
+
+    iter_task = asyncio.create_task(run_iter())
 
     await session.send_pcm(b'data')
     await asyncio.sleep(0.01)
     assert fake.sent == [b'data']
 
-    out1 = await asyncio.wait_for(session.out_q.get(), timeout=1)
-    out2 = await asyncio.wait_for(session.out_q.get(), timeout=1)
-    assert out1 == b'one' and out2 == b'two'
+    await asyncio.sleep(0.01)
+    assert outputs == [b'one', b'two']
 
     iter_task.cancel()
     send_task.cancel()

--- a/tests/test_mixer.py
+++ b/tests/test_mixer.py
@@ -3,27 +3,27 @@ from partybot.audio.mixer import Mixer
 
 
 def test_mixer_add_and_pop():
-    mixer = Mixer(sample_rate=10, channels=1, headroom_db=0)
+    mixer = Mixer(sample_rate=10, input_channels=1, headroom_db=0)
     pcm1 = np.full((5, 1), 0.1, dtype=np.float32)
     pcm2 = np.full((3, 1), 0.2, dtype=np.float32)
-    mixer.add(pcm1)
-    mixer.add(pcm2)
+    mixer.add(user_id=1, pcm_data=pcm1)
+    mixer.add(user_id=2, pcm_data=pcm2)
 
     chunk = mixer.pop(500)  # 5 frames at 10 Hz
     expected = np.array([0.3, 0.3, 0.3, 0.1, 0.1], dtype=np.float32)
     assert np.allclose(chunk.flatten(), expected)
     # buffer should now be empty
-    assert mixer.pop(100).shape[0] == 0
+    assert np.allclose(mixer.pop(100), np.zeros(1))
 
 
 def test_mixer_headroom_and_clear():
-    mixer = Mixer(sample_rate=4, channels=1, headroom_db=6)
+    mixer = Mixer(sample_rate=4, input_channels=1, headroom_db=6)
     pcm = np.full((4, 1), 1.0, dtype=np.float32)
-    mixer.add(pcm)
+    mixer.add(user_id=1, pcm_data=pcm)
     chunk = mixer.pop(1000)
     factor = 10 ** (-6 / 20)
     assert np.allclose(chunk.flatten(), np.ones(4) * factor)
 
-    mixer.add(np.full((1, 1), 0.5, dtype=np.float32))
+    mixer.add(user_id=1, pcm_data=np.full((1, 1), 0.5, dtype=np.float32))
     mixer.clear()
-    assert mixer.pop(1000).size == 0
+    assert np.allclose(mixer.pop(1000), np.zeros(4))


### PR DESCRIPTION
## Summary
- update Mixer tests for new API
- iterate `iter_audio` in Gemini session tests and capture outputs
- stub `discord.sinks.Sink` for import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686540e288a08329976a8d262456d068