### PR TITLE
Handle cost guard end condition

### DIFF
--- a/cog.py
+++ b/cog.py
@@ -134,6 +134,11 @@ class PartyBot(commands.Cog):
 
         except asyncio.CancelledError:
             self.logger.info(f"Voice session in {ctx.guild.name} cancelled.")
+        except RuntimeError as e:
+            if "cost guard" in str(e):
+                await ctx.send("Session ended: cost guard exceeded.")
+            else:
+                raise
         except Exception as e:
             self.logger.error(f"Error in voice session: {e}", exc_info=True)
             await ctx.send("An error occurred during the voice session.")


### PR DESCRIPTION
## Summary
- handle `Gemini session cost guard exceeded` errors in `_voice_session`
- test suite passes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68656e52f6688329a3594f8de194fcf6