### PR TITLE
Fix GeminiSession send loop lifecycle

### DIFF
--- a/tests/test_gemini_session.py
+++ b/tests/test_gemini_session.py
@@ -69,7 +69,7 @@ async def test_gemini_session_send_receive(monkeypatch):
 
     session = gs_mod.GeminiSession(api_key='k', model_id='m')
     await session.create()
-    send_task = asyncio.create_task(session._send_loop())
+    session.start_send_loop()
 
     outputs = []
 
@@ -87,6 +87,5 @@ async def test_gemini_session_send_receive(monkeypatch):
     assert outputs == [b'one', b'two']
 
     iter_task.cancel()
-    send_task.cancel()
     await session.close()
     assert fake.closed


### PR DESCRIPTION
## Summary
- track the send loop task on GeminiSession
- cancel the send loop when closing sessions
- update tests to use the public send loop API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68656e4dc14483299318dfc2d74bb6b1