### PR TITLE
Improve missing voice receiving check

### DIFF
--- a/partybot/__init__.py
+++ b/partybot/__init__.py
@@ -1,10 +1,15 @@
 """PartyBot package entry point."""
 
 from .logging import setup_logging
+import discord
 
 
 async def setup(bot):
     """Async entry point used by Red to load the cog."""
+    if not hasattr(discord.VoiceClient, "start_recording"):
+        raise RuntimeError(
+            "PartyBot requires py-cord >=2.6 with voice receiving support."
+        )
     from .cog import PartyBot
 
     await bot.add_cog(PartyBot(bot))

--- a/partybot/voice/discord_bridge.py
+++ b/partybot/voice/discord_bridge.py
@@ -57,7 +57,13 @@ class DiscordBridge:
     def __init__(self, vc: discord.VoiceClient):
         self._vc = vc
         self._receiver = _FrameReceiver(vc.loop)
-        self._vc.start_recording(self._receiver, self._on_record_finish)
+        if hasattr(self._vc, "start_recording"):
+            # py-cord >=2.6 exposes start_recording for voice receiving
+            self._vc.start_recording(self._receiver, self._on_record_finish)
+        else:  # pragma: no cover - older discord.py without voice receiving
+            raise RuntimeError(
+                "PartyBot requires a VoiceClient with voice receiving support."
+            )
 
     async def recv_frames(self) -> AsyncIterator[Tuple[int, np.ndarray]]:
         """Receives audio frames from Discord."""


### PR DESCRIPTION
## Summary
- ensure PartyBot fails fast when running on a discord.py build without voice receiving
- guard DiscordBridge usage of `start_recording`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68675d6763688329ac6c6256c3fe2e20